### PR TITLE
좋아요 및 조회 수 기능 구현

### DIFF
--- a/src/main/java/com/trade_ham/domain/auth/service/AuthService.java
+++ b/src/main/java/com/trade_ham/domain/auth/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
 
         // 응답 설정
         response.setHeader("access", newAccess);
-        System.out.println(newAccess);
+
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/com/trade_ham/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/trade_ham/domain/notification/controller/NotificationController.java
@@ -25,7 +25,7 @@ public class NotificationController {
         return ApiResponse.success(notifications);
     }
 
-    @PutMapping("/notification/{notoficationId}/toggle")
+    @PutMapping("/notification/{notificationId}/toggle")
     public ApiResponse<Long> notificationToggle(@AuthenticationPrincipal CustomOAuth2User oAuth2User, @PathVariable Long notificationId){
         notificationId = notificationService.changeNotificationStatus(notificationId);
 

--- a/src/main/java/com/trade_ham/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/trade_ham/domain/notification/entity/NotificationEntity.java
@@ -1,6 +1,7 @@
 package com.trade_ham.domain.notification.entity;
 
 import com.trade_ham.domain.auth.entity.UserEntity;
+import com.trade_ham.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class NotificationEntity {
+public class NotificationEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long notificationId;
@@ -38,7 +39,6 @@ public class NotificationEntity {
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now();
         this.isRead = false;
     }
 

--- a/src/main/java/com/trade_ham/domain/product/controller/SellProductController.java
+++ b/src/main/java/com/trade_ham/domain/product/controller/SellProductController.java
@@ -2,6 +2,7 @@ package com.trade_ham.domain.product.controller;
 
 import com.trade_ham.domain.auth.dto.CustomOAuth2User;
 import com.trade_ham.domain.product.dto.ProductDTO;
+import com.trade_ham.domain.product.dto.ProductDetailResponseDTO;
 import com.trade_ham.domain.product.dto.ProductResponseDTO;
 import com.trade_ham.domain.product.service.SellProductService;
 import com.trade_ham.global.common.response.ApiResponse;
@@ -42,14 +43,23 @@ public class SellProductController {
         return ApiResponse.success("삭제 완료");
     }
 
-
-
-
     // 상태가 SELL인 전체 판매 물품 최신순으로 조회
+    // 필요한 데이터만 전달
     @GetMapping("/all")
-    public ApiResponse<List<ProductResponseDTO>> findAllSellProducts() {
-        List<ProductResponseDTO> products = sellProductService.findAllSellProducts();
+    public ApiResponse<List<ProductResponseDTO>> findAllSellProducts(@AuthenticationPrincipal Long userId) {
+        List<ProductResponseDTO> products = sellProductService.findAllSellProducts(userId);
 
         return ApiResponse.success(products);
     }
+
+    // 물품 상세 페이지 제공
+    // 해당 물품 조회 수 증가
+    @GetMapping("/{productId}/detail")
+    public ApiResponse<ProductDetailResponseDTO> findProductDetail(@AuthenticationPrincipal Long userId, @PathVariable Long productId) {
+        ProductDetailResponseDTO product = sellProductService.findProductDetail(productId);
+
+        return ApiResponse.success(product);
+    }
+
+
 }

--- a/src/main/java/com/trade_ham/domain/product/controller/ViewLikeProductController.java
+++ b/src/main/java/com/trade_ham/domain/product/controller/ViewLikeProductController.java
@@ -1,0 +1,39 @@
+package com.trade_ham.domain.product.controller;
+
+import com.trade_ham.domain.product.dto.ProductResponseDTO;
+import com.trade_ham.domain.product.service.ViewLikeProductService;
+import com.trade_ham.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/product")
+public class ViewLikeProductController {
+
+    private final ViewLikeProductService viewLikeProductService;
+
+    @PatchMapping("/like/{productId}")
+    public ApiResponse<String> clickLikeButton(@AuthenticationPrincipal Long userId, @PathVariable Long productId) {
+        viewLikeProductService.incrementLike(userId, productId);
+
+        return ApiResponse.success("좋아요 완료");
+    }
+
+    @PatchMapping("/like/cancel/{productId}")
+    public ApiResponse<String> cancelLikeButton(@AuthenticationPrincipal Long userId, @PathVariable Long productId) {
+        viewLikeProductService.decrementLike(userId, productId);
+
+        return ApiResponse.success("좋아요 취소 완료");
+    }
+
+    @GetMapping("/likes")
+    public ApiResponse<List<ProductResponseDTO>> getUserLikes(@AuthenticationPrincipal Long userId) {
+        List<ProductResponseDTO> productResponseDTOS = viewLikeProductService.findUserLikeProducts(userId);
+
+        return ApiResponse.success(productResponseDTOS);
+    }
+}

--- a/src/main/java/com/trade_ham/domain/product/dto/ProductDetailResponseDTO.java
+++ b/src/main/java/com/trade_ham/domain/product/dto/ProductDetailResponseDTO.java
@@ -3,11 +3,9 @@ package com.trade_ham.domain.product.dto;
 import com.trade_ham.domain.product.entity.ProductEntity;
 import com.trade_ham.domain.product.entity.ProductStatus;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
-public class ProductResponseDTO {
+public class ProductDetailResponseDTO {
     private Long productId;
     private String name;
     private String description;
@@ -17,7 +15,7 @@ public class ProductResponseDTO {
     private Long like;
     private Boolean isLiked;
 
-    public ProductResponseDTO(ProductEntity productEntity) {
+    public ProductDetailResponseDTO(ProductEntity productEntity) {
         this.productId = productEntity.getProductId();
         this.name = productEntity.getName();
         this.description = productEntity.getDescription();

--- a/src/main/java/com/trade_ham/domain/product/entity/ProductEntity.java
+++ b/src/main/java/com/trade_ham/domain/product/entity/ProductEntity.java
@@ -2,6 +2,7 @@ package com.trade_ham.domain.product.entity;
 
 import com.trade_ham.domain.auth.entity.UserEntity;
 import com.trade_ham.domain.locker.entity.LockerEntity;
+import com.trade_ham.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,7 +16,7 @@ import java.util.Date;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductEntity {
+public class ProductEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long productId;
@@ -45,14 +46,11 @@ public class ProductEntity {
     @JoinColumn(name = "locker_id")
     private LockerEntity lockerEntity;
 
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+    @Builder.Default
+    private Long views = 0L;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
+    @Builder.Default
+    private Long likes = 0L;
 
     public void updateProduct(String name, String description, Long price){
         this.name = name;
@@ -60,4 +58,17 @@ public class ProductEntity {
         this.price = price;
     }
 
+    public void increaseLikes(){
+        this.likes++;
+    }
+
+    public void decreaseLikes(){
+        if(this.likes>0){
+            this.likes--;
+        }
+    }
+
+    public void increaseViews(){
+        this.views++;
+    }
 }

--- a/src/main/java/com/trade_ham/domain/product/service/SearchProductService.java
+++ b/src/main/java/com/trade_ham/domain/product/service/SearchProductService.java
@@ -2,7 +2,6 @@ package com.trade_ham.domain.product.service;
 
 import com.trade_ham.domain.product.dto.ProductResponseDTO;
 import com.trade_ham.domain.product.entity.ProductEntity;
-import com.trade_ham.domain.product.entity.ProductStatus;
 import com.trade_ham.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +17,7 @@ public class SearchProductService {
     @Transactional(readOnly = true)
     public List<ProductResponseDTO> searchProducts(String keyword) {
         List<ProductEntity> products = productRepository.searchProducts(keyword);
+
         return products.stream()
                 .map(ProductResponseDTO::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/trade_ham/domain/product/service/SellProductService.java
+++ b/src/main/java/com/trade_ham/domain/product/service/SellProductService.java
@@ -2,6 +2,7 @@ package com.trade_ham.domain.product.service;
 
 import com.trade_ham.domain.auth.entity.UserEntity;
 import com.trade_ham.domain.auth.repository.UserRepository;
+import com.trade_ham.domain.product.dto.ProductDetailResponseDTO;
 import com.trade_ham.domain.product.entity.ProductEntity;
 import com.trade_ham.domain.product.entity.ProductStatus;
 import com.trade_ham.domain.product.dto.ProductDTO;
@@ -10,16 +11,22 @@ import com.trade_ham.domain.product.repository.ProductRepository;
 import com.trade_ham.global.common.exception.ErrorCode;
 import com.trade_ham.global.common.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
+
+import static com.trade_ham.domain.product.service.ViewLikeProductService.USER_LIKED_PRODUCTS_KEY_PREFIX;
+
 
 @Service
 @RequiredArgsConstructor
 public class SellProductService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisSetTemplate; // Set 타입 Redis 관리
+
 
     // 물품 올리기
     public ProductResponseDTO createProduct(ProductDTO productDTO, Long sellerId) {
@@ -49,9 +56,7 @@ public class SellProductService {
 
         productEntity.updateProduct(productDTO.getName(), productDTO.getDescription(), productDTO.getPrice());
 
-        ProductEntity updatedProductEntity = productRepository.save(productEntity);
-
-        return new ProductResponseDTO(updatedProductEntity);
+        return new ProductResponseDTO(productEntity);
     }
 
     // 물품 삭제
@@ -69,14 +74,36 @@ public class SellProductService {
     }
 
 
-
     // 상태가 SELL인 전체 판매 물품 최신순 조회
     // N+1 문제 발생 예상 지역
-    public List<ProductResponseDTO> findAllSellProducts() {
+    /*
+    게시물들을 RDB에서 들고온다.
+    레디스를 통해 해당 게시물에 사용자가 좋아요를 누른 이력이 있는지 확인하고 DTO에 담아 반환
+     */
+    public List<ProductResponseDTO> findAllSellProducts(Long userId) {
+        String userLikedProductsKey = USER_LIKED_PRODUCTS_KEY_PREFIX + userId;
+
         List<ProductEntity> productEntities = productRepository.findByStatusOrderByCreatedAtDesc(ProductStatus.SELL);
 
+        Set<String> likedProductIds = redisSetTemplate.opsForSet().members(userLikedProductsKey);
+
+
         return productEntities.stream()
-                .map(ProductResponseDTO::new)
-                .collect(Collectors.toList());
+                .map(product -> {
+                    ProductResponseDTO responseDTO = new ProductResponseDTO(product);
+                    responseDTO.setIsLiked(likedProductIds != null && likedProductIds.contains(String.valueOf(product.getProductId())));
+                    return responseDTO;
+                })
+                .toList();
+    }
+
+    public ProductDetailResponseDTO findProductDetail(Long productId) {
+        ProductEntity productEntity = productRepository.findByProductId(productId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 조회 수 증가
+        productEntity.increaseViews();
+
+        return new ProductDetailResponseDTO(productEntity);
     }
 }

--- a/src/main/java/com/trade_ham/domain/product/service/ViewLikeProductService.java
+++ b/src/main/java/com/trade_ham/domain/product/service/ViewLikeProductService.java
@@ -1,0 +1,95 @@
+package com.trade_ham.domain.product.service;
+
+import com.trade_ham.domain.product.dto.ProductResponseDTO;
+import com.trade_ham.domain.product.entity.ProductEntity;
+import com.trade_ham.domain.product.repository.ProductRepository;
+import com.trade_ham.global.common.exception.ErrorCode;
+import com.trade_ham.global.common.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ViewLikeProductService {
+
+    private final ProductRepository productRepository;
+    private final RedisTemplate<String, String> redisSetTemplate; // Set 타입 Redis 관리
+
+
+    public static final String USER_LIKED_PRODUCTS_KEY_PREFIX = "user:like:products:";
+
+
+    /*
+    좋아요 클릭 이벤트
+    레디스 : key=userId, value=set(유저가 좋아요를 누른 게시물)
+    사용자 좋아요 수를 올리고 레디스에 사용자가 좋아요 누른 게시물을 추가
+     */
+    @Transactional
+    public void incrementLike(Long userId, Long productId) {
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        String userLikedProductsKey = USER_LIKED_PRODUCTS_KEY_PREFIX + userId;
+
+        Long temp_size = redisSetTemplate.opsForSet().size(userLikedProductsKey);
+
+        // 사용자가 좋아요한 게시물 목록에 추가
+        redisSetTemplate.opsForSet().add(userLikedProductsKey, String.valueOf(productId));
+
+        // 좋아요 이미 좋아요가 없을 때만 좋아요 증가 반영
+        if (!Objects.equals(temp_size, redisSetTemplate.opsForSet().size(userLikedProductsKey))) {
+            productEntity.increaseLikes();
+        }
+
+    }
+
+    @Transactional
+    public void decrementLike(Long userId, Long productId) {
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        String userLikedProductsKey = USER_LIKED_PRODUCTS_KEY_PREFIX + userId;
+
+        Long temp_size = redisSetTemplate.opsForSet().size(userLikedProductsKey);
+
+        // 사용자가 좋아요한 게시물 목록에서 제거
+        redisSetTemplate.opsForSet().remove(userLikedProductsKey, String.valueOf(productId));
+
+        // 사용자가 좋아요한 게시물 목록에 있었을 때만 제거
+        if (!Objects.equals(temp_size, redisSetTemplate.opsForSet().size(userLikedProductsKey))) {
+            productEntity.decreaseLikes();
+        }
+    }
+
+    public List<ProductResponseDTO> findUserLikeProducts(Long userId) {
+        String userLikedProductsKey = USER_LIKED_PRODUCTS_KEY_PREFIX + userId;
+
+        Set<String> likedProductIds = redisSetTemplate.opsForSet().members(userLikedProductsKey);
+
+        // Redis에 좋아요한 게시물이 없는 경우 빈 리스트 반환
+        if (likedProductIds == null || likedProductIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 데이터베이스에서 해당 게시물 ID로 조회
+        List<Long> productIds = likedProductIds.stream()
+                .map(Long::valueOf)
+                .toList();
+
+        List<ProductEntity> productEntities = productRepository.findAllById(productIds);
+
+        return productEntities.stream()
+                .map(product -> {
+                    ProductResponseDTO responseDTO = new ProductResponseDTO(product);
+                    responseDTO.setIsLiked(true); // 사용자가 좋아요를 누른 게시물이므로 true로 설정
+                    return responseDTO;
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
- 물품 리스트 반환 API와 물품 상세 페이지 조회 API를 분리
- 조회 수 기능 구현
    - 상품 엔티티에 좋아요 컬럼 추가
    - 물품 상세 페이지 조회 시 조회 수 증가
    - 조회 수에 대한 데이터는 중요하지 않다고 생각하여 동시성을 고려해주지 않음
- 좋아요 기능 구현
    - 상품 엔티티에 좋아요 컬럼 추가
    - 사용자가 좋아요 클릭 시 엔티티의 좋아요 수 증가
    - 레디스에 Key: UserId, Value: SET(postIds)의 Value에 해당 물품의 아이디 추가
    - 어떤 사용자가 좋아요를 눌렀는지 어떤 물품에 대한 좋아요를 눌렀는지에 대한 정보는 중요하지만 좋아요 수에 대한 것은 음수로 가지만 않으면 크게 중요하지 않다고 생각하여 좋아요 수에 대해서는 동시성을 고려해주지 않음
    - 이에 대한 이점
        - 해당 포스트에 대해서 유저가 좋아요를 눌렀는지 보려면 Set을 탐색 → O(1)
        - 유저가 찜한 목록 갯수를 보여주기 쉬움 → O(1)